### PR TITLE
Fixed #19: Changed behaviour of "show hints" slider

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -17,6 +17,7 @@ $(document).ready(function () {
     let toohigh = false,toolow=false;
     let diffbox = $('input[name=radio]:radio');
     let max = $('#max');
+    let mouseX = 0;
     input.on('keyup',function (event) {
        if(event.keyCode===13){
            guessbtn.click();
@@ -206,6 +207,19 @@ $(document).ready(function () {
     });
     $('#cll').click(function () {
         $('#resetbtn').click();
+    });
+    $('.switch').mousedown(function () {
+        mouseX = event.clientX;
+    });
+    $('.switch').mouseup(function () {
+        if (mouseX && (event.clientX < mouseX && !ischecked || event.clientX > mouseX && ischecked))
+            cbox.click();
+        mouseX = 0;
+    });
+    $('body').mouseup(function () {
+        if (mouseX && (event.clientX < mouseX && ischecked || event.clientX > mouseX && !ischecked))                   
+            cbox.click();
+        mouseX = 0; 
     });
 
 });


### PR DESCRIPTION
Before changes slider changed his state in the following case:

- you clicked and released button inside slider

After changes:

- you clicked inside slider and released button in the same coordinate
- or you clicked inside slider, moved mouse to the correct side and released button

That's, if slider is inactive, you click on it, move mouse to the left, and release button, slider will not change its state
Now, slider behaves like real slider
I did not remove Bootstrap class from slider