### PR TITLE
Fix "Too smart for hints" text flashing screen on reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
                     <div class="hcontent center-block text-center">
 
                     </div>
-                    <h1 id="tsfd" class="text-center" style="color: blue" >Too smart for hints</h1>
+                    <h1 id="tsfd" class="text-center" style="color: blue; display: none" >Too smart for hints</h1>
                 </div>
             </div>
 

--- a/js/index.js
+++ b/js/index.js
@@ -3,7 +3,6 @@ function getrandomnumber(min,max) {
 }
 
 $(document).ready(function () {
-    $('#tsfd').hide();
     let rand = getrandomnumber(1,100);
 
     let guesspanel = $('#guesspanel');


### PR DESCRIPTION
Hide the "Too smart for hints" element by default in the html file. This removes the need to hide the text on page load.